### PR TITLE
Changed flags to args to make it a cleaner command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Creates new components for neon
 
 ```
 USAGE
-  $ neon make
+  $ neon make TYPE NAME
 
-OPTIONS
-  -n, --name=name  name of new component
-  -t, --type=type  type of new component
+ARGUMENTS
+  TYPE  [default: layout] The type of component.
+  NAME  [default: NewFile] The name of component.
 
 DESCRIPTION
   ...

--- a/src/commands/make.js
+++ b/src/commands/make.js
@@ -1,4 +1,4 @@
-const {Command, flags} = require('@oclif/command')
+const {Command} = require('@oclif/command')
 const fs = require('fs')
 const {cli} = require('cli-ux')
 const {componentTemplate} = require('../templates/component')
@@ -6,10 +6,9 @@ const {componentTemplate} = require('../templates/component')
 
 class MakeCommand extends Command {
   async run() {
-    const {flags} = this.parse(MakeCommand)
-    const name = flags.name || 'NewFile'
-    const type = flags.type || 'layout'
-
+    const {args} = this.parse(MakeCommand)
+    const type = args.type
+    const name = args.name
     const folderName = `./src/components/${type}s/${name}`
 
     try {
@@ -61,9 +60,19 @@ With this command, you can create a new component in the appropriate directory.
 Makes the right thing the easy thing.
 `
 
-MakeCommand.flags = {
-  type: flags.string({char: 't', description: 'type of new component'}),
-  name: flags.string({char: 'n', description: 'name of new component'}),
-}
+MakeCommand.args = [
+  {
+    name: 'type',
+    required: true,
+    description: 'The type of component.',
+    default: 'layout',
+  },
+  {
+    name: 'name',
+    required: true,
+    description: 'The name of component.',
+    default: 'NewFile',
+  },
+]
 
 module.exports = MakeCommand


### PR DESCRIPTION
Never really done this before. But, I was thinking it would be better to have the "make" command pass args instead of flags. So, the new way would be `neon make layout Billboard`

USAGE
  $ neon make TYPE NAME

ARGUMENTS
  TYPE  [default: layout] The type of component.
  NAME  [default: NewFile] The name of component.